### PR TITLE
Travis CI for automated testing of all pull requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+group: travis_latest
+language: python
+cache: pip
+python:
+    - 3.6
+install:
+    #- pip install -r requirements.txt
+    - pip install flake8  # pytest  # add another testing frameworks later
+before_script:
+    # stop the build if there are Python syntax errors or undefined names
+    - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+    # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+    - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+script:
+    - true  # pytest --capture=sys  # add other tests here
+notifications:
+    on_success: change
+    on_failure: change  # `always` will be the setting once code changes slow down


### PR DESCRIPTION
Travis Continuous Integration service can run automated testing using [flake8](http://flake8.pycqa.org) on all pull requests.  Travis CI is free for all open source projects like this one and to turn it on, visit https://travis-ci.com/kraigu  This config file will have Travis CI run flake8 tests to find Python syntax errors and undefined names in all pull requests before they are reviewed.  Output: #1